### PR TITLE
bump(stix2): Bump Stix2 to 3.0.1 for opencti compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 maltego-trx==1.3.8
-stix2==2.1.0
+stix2==3.0.1
 six>=1.4.0
 markdown==3.3.4
 pycti>=5.2.4
-maltego-stix2>=2.1.1
+maltego-stix2>=2.1.2


### PR DESCRIPTION
Depends on https://github.com/amr-cossi/maltego-stix2/pull/15
Fixes #12 